### PR TITLE
Counter should to be a "dump" component w/o referencing to all Redux actions

### DIFF
--- a/examples/counter/components/Counter.ts
+++ b/examples/counter/components/Counter.ts
@@ -3,21 +3,19 @@ import {Component, View, ON_PUSH} from 'angular2/angular2';
 @Component({
   selector: 'counter',
   changeDetection: ON_PUSH,
-  properties: ['counter', 'actions']
+  properties: ['counter', 'increment', 'decrement', 'incrementIfOdd']
 })
 @View({
   directives: [],
   template: `
   <p>
     Clicked: {{ counter }} times
-    <button (^click)="actions.increment()">+</button>
-    <button (^click)="actions.decrement()">-</button>
-    <button (^click)="actions.incrementIfOdd()">Increment if odd</button>
+    <button (^click)="increment()">+</button>
+    <button (^click)="decrement()">-</button>
+    <button (^click)="incrementIfOdd()">Increment if odd</button>
   </p>
   `
 })
 export class Counter {
-  counter: number;
-  actions: any;
   constructor() {}
 }

--- a/examples/counter/containers/CounterApp.ts
+++ b/examples/counter/containers/CounterApp.ts
@@ -12,7 +12,10 @@ import { Inject } from 'angular2/di';
 @View({
   directives: [Counter],
   template: `
-  <counter [counter]="counter" [actions]="actions"></counter>
+  <counter [counter]="counter"
+    [increment]="increment"
+    [decrement]="decrement"
+    [increment-If-Odd]="incrementIfOdd"></counter>
   `
 })
 export class CounterApp {
@@ -36,6 +39,6 @@ export class CounterApp {
   }
 
   mapDispatchToProps(dispatch) {
-    return { actions: bindActionCreators(CounterActions, dispatch) };
+    return bindActionCreators(CounterActions, dispatch);
   }
 }


### PR DESCRIPTION
Just an improvement: To have really a "dump" Counter component it should not have a reference to all actions. The Counter component receives its data as properties as usual, but just the action handler as needed (not all actions).