### PR TITLE
Support of TypeScript 1.6

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -42,7 +42,7 @@
     "node-libs-browser": "^0.5.2",
     "react-hot-loader": "^1.2.7",
     "tsd": "^0.6.4",
-    "typescript": "git://github.com/Microsoft/TypeScript.git#release-1.5",
+    "typescript": "^1.6.2",
     "typescript-simple-loader": "^0.2.0",
     "webpack": "^1.9.11",
     "webpack-dev-server": "^1.9.0"

--- a/examples/counter/reducers/counter.ts
+++ b/examples/counter/reducers/counter.ts
@@ -1,16 +1,12 @@
 import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../actions/CounterActions';
 
-export default (state:number, action:any) => {
-  // to avoid tsc error  "A required parameter cannot follow an optional
-  // parameter. (1016)" set default value of state here
-  state = (state || 0);
-
+export default (state:number = 0, action:any) => {
   switch (action.type) {
-  case INCREMENT_COUNTER:
-    return state + 1;
-  case DECREMENT_COUNTER:
-    return state - 1;
-  default:
-    return state;
+    case INCREMENT_COUNTER:
+      return state + 1;
+    case DECREMENT_COUNTER:
+      return state - 1;
+    default:
+      return state;
   }
 }

--- a/examples/counter/tsconfig.json
+++ b/examples/counter/tsconfig.json
@@ -1,23 +1,41 @@
 {
-  "version": "1.5.0",
-  "compilerOptions": {
-    "target": "es5",
-    "module": "commonjs",
-    "declaration": false,
-    "noImplicitAny": false,
-    "removeComments": true,
-    "noLib": false,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "sourceMap": true,
-    "listFiles": true,
-    "outDir": "dist"
-  },
-  "files": [
-    "./node_modules/typescript/bin/lib.dom.d.ts",
-    "./typings/_custom/custom.d.ts",
-    "./typings/tsd.d.ts",
-    "./containers/App.ts",
-    "./bootstrap.ts"
-  ]
+    "version": "1.6.2",
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": false,
+        "noImplicitAny": false,
+        "removeComments": true,
+        "noLib": false,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "sourceMap": true,
+        "listFiles": true,
+        "moduleResolution": "classic",
+        "outDir": "dist"
+    },
+    "filesGlob": [
+        "./**/*.ts",
+        "!./node_modules/**/*.ts"
+    ],
+    "files": [
+        "./actions/CounterActions.ts",
+        "./components/Counter.ts",
+        "./components/hello.ts",
+        "./containers/App.ts",
+        "./index.ts",
+        "./reducers/counter.ts",
+        "./reducers/index.ts",
+        "./store/configureStore.ts",
+        "./typings/_custom/browser.d.ts",
+        "./typings/_custom/custom.d.ts",
+        "./typings/_custom/ng2.d.ts",
+        "./typings/_custom/webpack.d.ts",
+        "./typings/angular2/angular2.d.ts",
+        "./typings/es6-promise/es6-promise.d.ts",
+        "./typings/redux/redux.d.ts",
+        "./typings/rx/rx-lite.d.ts",
+        "./typings/rx/rx.d.ts",
+        "./typings/tsd.d.ts"
+    ]
 }


### PR DESCRIPTION
Upgrade to latest TS 1.6 to support "[Default initializers on required parameters](https://github.com/Microsoft/TypeScript/pull/4022)" and [all the sugar](http://blogs.msdn.com/b/typescript/archive/2015/09/16/announcing-typescript-1-6.aspx).